### PR TITLE
Add rank 11 missions 9 and 10

### DIFF
--- a/src/main/resources/inventories/rang11.yml
+++ b/src/main/resources/inventories/rang11.yml
@@ -1,0 +1,90 @@
+name: "#edacfcMissions #ff94d7Rang XI"
+size: 54
+items:
+
+  back:
+    type: INVENTORY
+    inventory: quests
+    slot: 49
+    item:
+      material: ARROW
+      name: "&fRetour"
+
+  history:
+    type: INVENTORY
+    inventory: quests-history
+    slot: 50
+    item:
+      material: CLOCK
+      name: "&fHistorique"
+
+  mission-9:
+    pattern:
+      fileName: quest-display
+      pluginName: zQuests
+      slot: 21
+      number: 9
+      quests:
+        - "rang11_mission9_end_stone_break"
+        - "rang11_mission9_end_stone_bricks_craft"
+        - "rang11_mission9_end_stone_brick_stairs_craft"
+        - "rang11_mission9_end_stone_brick_slab_craft"
+        - "rang11_mission9_end_stone_brick_wall_craft"
+        - "rang11_mission9_shulker_kill"
+        - "rang11_mission9_shulker_box_craft"
+      objectives:
+        - " %zquests_description_rang11_mission9_end_stone_break% %zquests_favorite_icon_rang11_mission9_end_stone_break%"
+        - "%zquests_lore_line_rang11_mission9_end_stone_break%"
+        - " %zquests_description_rang11_mission9_end_stone_bricks_craft% %zquests_favorite_icon_rang11_mission9_end_stone_bricks_craft%"
+        - "%zquests_lore_line_rang11_mission9_end_stone_bricks_craft%"
+        - " %zquests_description_rang11_mission9_end_stone_brick_stairs_craft% %zquests_favorite_icon_rang11_mission9_end_stone_brick_stairs_craft%"
+        - "%zquests_lore_line_rang11_mission9_end_stone_brick_stairs_craft%"
+        - " %zquests_description_rang11_mission9_end_stone_brick_slab_craft% %zquests_favorite_icon_rang11_mission9_end_stone_brick_slab_craft%"
+        - "%zquests_lore_line_rang11_mission9_end_stone_brick_slab_craft%"
+        - " %zquests_description_rang11_mission9_end_stone_brick_wall_craft% %zquests_favorite_icon_rang11_mission9_end_stone_brick_wall_craft%"
+        - "%zquests_lore_line_rang11_mission9_end_stone_brick_wall_craft%"
+        - " %zquests_description_rang11_mission9_shulker_kill% %zquests_favorite_icon_rang11_mission9_shulker_kill%"
+        - "%zquests_lore_line_rang11_mission9_shulker_kill%"
+        - " %zquests_description_rang11_mission9_shulker_box_craft% %zquests_favorite_icon_rang11_mission9_shulker_box_craft%"
+        - "%zquests_lore_line_rang11_mission9_shulker_box_craft%"
+      rewards:
+        - " &8• &fRécompenses de mission"
+
+  mission-10:
+    pattern:
+      fileName: quest-display
+      pluginName: zQuests
+      slot: 23
+      number: 10
+      quests:
+        - "rang11_mission10_netherite_block_deliver"
+        - "rang11_mission10_diamond_block_deliver"
+        - "rang11_mission10_emerald_block_deliver"
+        - "rang11_mission10_iron_block_deliver"
+        - "rang11_mission10_coal_block_deliver"
+        - "rang11_mission10_lapis_block_deliver"
+        - "rang11_mission10_redstone_block_deliver"
+        - "rang11_mission10_copper_block_deliver"
+        - "rang11_mission10_wither_skull_deliver"
+      objectives:
+        - " %zquests_description_rang11_mission10_netherite_block_deliver% %zquests_favorite_icon_rang11_mission10_netherite_block_deliver%"
+        - "%zquests_lore_line_rang11_mission10_netherite_block_deliver%"
+        - " %zquests_description_rang11_mission10_diamond_block_deliver% %zquests_favorite_icon_rang11_mission10_diamond_block_deliver%"
+        - "%zquests_lore_line_rang11_mission10_diamond_block_deliver%"
+        - " %zquests_description_rang11_mission10_emerald_block_deliver% %zquests_favorite_icon_rang11_mission10_emerald_block_deliver%"
+        - "%zquests_lore_line_rang11_mission10_emerald_block_deliver%"
+        - " %zquests_description_rang11_mission10_iron_block_deliver% %zquests_favorite_icon_rang11_mission10_iron_block_deliver%"
+        - "%zquests_lore_line_rang11_mission10_iron_block_deliver%"
+        - " %zquests_description_rang11_mission10_coal_block_deliver% %zquests_favorite_icon_rang11_mission10_coal_block_deliver%"
+        - "%zquests_lore_line_rang11_mission10_coal_block_deliver%"
+        - " %zquests_description_rang11_mission10_lapis_block_deliver% %zquests_favorite_icon_rang11_mission10_lapis_block_deliver%"
+        - "%zquests_lore_line_rang11_mission10_lapis_block_deliver%"
+        - " %zquests_description_rang11_mission10_redstone_block_deliver% %zquests_favorite_icon_rang11_mission10_redstone_block_deliver%"
+        - "%zquests_lore_line_rang11_mission10_redstone_block_deliver%"
+        - " %zquests_description_rang11_mission10_copper_block_deliver% %zquests_favorite_icon_rang11_mission10_copper_block_deliver%"
+        - "%zquests_lore_line_rang11_mission10_copper_block_deliver%"
+        - " %zquests_description_rang11_mission10_wither_skull_deliver% %zquests_favorite_icon_rang11_mission10_wither_skull_deliver%"
+        - "%zquests_lore_line_rang11_mission10_wither_skull_deliver%"
+      rewards:
+        - " &8• &fRécompenses de mission"
+

--- a/src/main/resources/quests/rang11/mission-10.yml
+++ b/src/main/resources/quests/rang11/mission-10.yml
@@ -1,0 +1,145 @@
+quests:
+  - type: INVENTORY_CONTENT
+    actions:
+      - material: NETHERITE_BLOCK
+        citizen-name: intendant
+    name: "rang11_mission10_netherite_block_deliver"
+    display-name: "Rang 11 - Mission 10"
+    description: "#edacfcApporter #ff94d72 #edacfcblocs de netherite à l'Intendant"
+    placeholder-description: "#edacfcApporter #ff94d7%quest-remaining% #edacfcblocs de netherite à l'Intendant"
+    thumbnail: NETHERITE_BLOCK
+    goal: 2
+    auto-accept: true
+    rewards:
+      - type: message
+        messages:
+          - "#edacfcL'Intendant reçoit la netherite avec gratitude."
+
+  - type: INVENTORY_CONTENT
+    actions:
+      - material: DIAMOND_BLOCK
+        citizen-name: intendant
+    name: "rang11_mission10_diamond_block_deliver"
+    display-name: "Rang 11 - Mission 10"
+    description: "#edacfcApporter #ff94d716 #edacfcblocs de diamant à l'Intendant"
+    placeholder-description: "#edacfcApporter #ff94d7%quest-remaining% #edacfcblocs de diamant à l'Intendant"
+    thumbnail: DIAMOND_BLOCK
+    goal: 16
+    auto-accept: true
+    rewards:
+      - type: message
+        messages:
+          - "#edacfcLes réserves de diamants sont impeccables !"
+
+  - type: INVENTORY_CONTENT
+    actions:
+      - material: EMERALD_BLOCK
+        citizen-name: intendant
+    name: "rang11_mission10_emerald_block_deliver"
+    display-name: "Rang 11 - Mission 10"
+    description: "#edacfcApporter #ff94d732 #edacfcblocs d'émeraude à l'Intendant"
+    placeholder-description: "#edacfcApporter #ff94d7%quest-remaining% #edacfcblocs d'émeraude à l'Intendant"
+    thumbnail: EMERALD_BLOCK
+    goal: 32
+    auto-accept: true
+    rewards:
+      - type: message
+        messages:
+          - "#edacfcLes coffres d'émeraudes sont bien remplis."
+
+  - type: INVENTORY_CONTENT
+    actions:
+      - material: IRON_BLOCK
+        citizen-name: intendant
+    name: "rang11_mission10_iron_block_deliver"
+    display-name: "Rang 11 - Mission 10"
+    description: "#edacfcApporter #ff94d764 #edacfcblocs de fer à l'Intendant"
+    placeholder-description: "#edacfcApporter #ff94d7%quest-remaining% #edacfcblocs de fer à l'Intendant"
+    thumbnail: IRON_BLOCK
+    goal: 64
+    auto-accept: true
+    rewards:
+      - type: message
+        messages:
+          - "#edacfcUn stock de fer impressionnant est livré."
+
+  - type: INVENTORY_CONTENT
+    actions:
+      - material: COAL_BLOCK
+        citizen-name: intendant
+    name: "rang11_mission10_coal_block_deliver"
+    display-name: "Rang 11 - Mission 10"
+    description: "#edacfcApporter #ff94d7128 #edacfcblocs de charbon à l'Intendant"
+    placeholder-description: "#edacfcApporter #ff94d7%quest-remaining% #edacfcblocs de charbon à l'Intendant"
+    thumbnail: COAL_BLOCK
+    goal: 128
+    auto-accept: true
+    rewards:
+      - type: message
+        messages:
+          - "#edacfcLe charbon afflue dans les entrepôts du royaume."
+
+  - type: INVENTORY_CONTENT
+    actions:
+      - material: LAPIS_BLOCK
+        citizen-name: intendant
+    name: "rang11_mission10_lapis_block_deliver"
+    display-name: "Rang 11 - Mission 10"
+    description: "#edacfcApporter #ff94d7128 #edacfcblocs de lapis à l'Intendant"
+    placeholder-description: "#edacfcApporter #ff94d7%quest-remaining% #edacfcblocs de lapis à l'Intendant"
+    thumbnail: LAPIS_BLOCK
+    goal: 128
+    auto-accept: true
+    rewards:
+      - type: message
+        messages:
+          - "#edacfcLes enchanteurs remercient ta livraison de lapis."
+
+  - type: INVENTORY_CONTENT
+    actions:
+      - material: REDSTONE_BLOCK
+        citizen-name: intendant
+    name: "rang11_mission10_redstone_block_deliver"
+    display-name: "Rang 11 - Mission 10"
+    description: "#edacfcApporter #ff94d7128 #edacfcblocs de redstone à l'Intendant"
+    placeholder-description: "#edacfcApporter #ff94d7%quest-remaining% #edacfcblocs de redstone à l'Intendant"
+    thumbnail: REDSTONE_BLOCK
+    goal: 128
+    auto-accept: true
+    rewards:
+      - type: message
+        messages:
+          - "#edacfcLa redstone se met à circuler dans toutes les machines."
+
+  - type: INVENTORY_CONTENT
+    actions:
+      - material: COPPER_BLOCK
+        citizen-name: intendant
+    name: "rang11_mission10_copper_block_deliver"
+    display-name: "Rang 11 - Mission 10"
+    description: "#edacfcApporter #ff94d7128 #edacfcblocs de cuivre à l'Intendant"
+    placeholder-description: "#edacfcApporter #ff94d7%quest-remaining% #edacfcblocs de cuivre à l'Intendant"
+    thumbnail: COPPER_BLOCK
+    goal: 128
+    auto-accept: true
+    rewards:
+      - type: message
+        messages:
+          - "#edacfcLe cuivre frais est prêt pour les artisans du royaume."
+
+  - type: INVENTORY_CONTENT
+    actions:
+      - material: WITHER_SKELETON_SKULL
+        citizen-name: intendant
+    name: "rang11_mission10_wither_skull_deliver"
+    display-name: "Rang 11 - Mission 10"
+    description: "#edacfcApporter #ff94d764 #edacfctêtes de wither à l'Intendant"
+    placeholder-description: "#edacfcApporter #ff94d7%quest-remaining% #edacfctêtes de wither à l'Intendant"
+    thumbnail: WITHER_SKELETON_SKULL
+    goal: 64
+    auto-accept: true
+    rewards:
+      - type: message
+        messages:
+          - "#edacfcL'Intendant garde précieusement ces têtes de wither."
+

--- a/src/main/resources/quests/rang11/mission-9.yml
+++ b/src/main/resources/quests/rang11/mission-9.yml
@@ -1,0 +1,106 @@
+quests:
+  - type: BLOCK_BREAK
+    actions:
+      - material: END_STONE
+    name: "rang11_mission9_end_stone_break"
+    display-name: "Rang 11 - Mission 9"
+    description: "#edacfcCasser #ff94d75000 #edacfcblocs de pierre de l'End"
+    placeholder-description: "#edacfcCasser #ff94d7%quest-remaining% #edacfcblocs de pierre de l'End"
+    thumbnail: END_STONE
+    goal: 5000
+    auto-accept: true
+    rewards:
+      - type: message
+        messages:
+          - "#edacfcTu as extrait la pierre de l'End avec succès !"
+
+  - type: CRAFT
+    actions:
+      - material: END_STONE_BRICKS
+    name: "rang11_mission9_end_stone_bricks_craft"
+    display-name: "Rang 11 - Mission 9"
+    description: "#edacfcCrafter #ff94d75000 #edacfcblocs de pierre taillée de l'End"
+    placeholder-description: "#edacfcCrafter #ff94d7%quest-remaining% #edacfcblocs de pierre taillée de l'End"
+    thumbnail: END_STONE_BRICKS
+    goal: 5000
+    auto-accept: true
+    rewards:
+      - type: message
+        messages:
+          - "#edacfcLa pierre taillée de l'End remplit tes coffres !"
+
+  - type: CRAFT
+    actions:
+      - material: END_STONE_BRICK_STAIRS
+    name: "rang11_mission9_end_stone_brick_stairs_craft"
+    display-name: "Rang 11 - Mission 9"
+    description: "#edacfcCrafter #ff94d72500 #edacfcescaliers en pierre taillée de l'End"
+    placeholder-description: "#edacfcCrafter #ff94d7%quest-remaining% #edacfcescaliers en pierre taillée de l'End"
+    thumbnail: END_STONE_BRICK_STAIRS
+    goal: 2500
+    auto-accept: true
+    rewards:
+      - type: message
+        messages:
+          - "#edacfcCes escaliers guideront tes conquêtes endériennes."
+
+  - type: CRAFT
+    actions:
+      - material: END_STONE_BRICK_SLAB
+    name: "rang11_mission9_end_stone_brick_slab_craft"
+    display-name: "Rang 11 - Mission 9"
+    description: "#edacfcCrafter #ff94d72500 #edacfcdalles de pierre taillée de l'End"
+    placeholder-description: "#edacfcCrafter #ff94d7%quest-remaining% #edacfcdalles de pierre taillée de l'End"
+    thumbnail: END_STONE_BRICK_SLAB
+    goal: 2500
+    auto-accept: true
+    rewards:
+      - type: message
+        messages:
+          - "#edacfcLes dalles de l'End sont prêtes pour tes constructions."
+
+  - type: CRAFT
+    actions:
+      - material: END_STONE_BRICK_WALL
+    name: "rang11_mission9_end_stone_brick_wall_craft"
+    display-name: "Rang 11 - Mission 9"
+    description: "#edacfcCrafter #ff94d72500 #edacfcmurets en pierre taillée de l'End"
+    placeholder-description: "#edacfcCrafter #ff94d7%quest-remaining% #edacfcmurets en pierre taillée de l'End"
+    thumbnail: END_STONE_BRICK_WALL
+    goal: 2500
+    auto-accept: true
+    rewards:
+      - type: message
+        messages:
+          - "#edacfcDes remparts d'Ender se dressent grâce à toi !"
+
+  - type: ENTITY_KILL
+    actions:
+      - entity: SHULKER
+    name: "rang11_mission9_shulker_kill"
+    display-name: "Rang 11 - Mission 9"
+    description: "#edacfcTuer #ff94d7200 #edacfcShulkers"
+    placeholder-description: "#edacfcTuer #ff94d7%quest-remaining% #edacfcShulkers"
+    thumbnail: SHULKER_SHELL
+    goal: 200
+    auto-accept: true
+    rewards:
+      - type: message
+        messages:
+          - "#edacfcLes Shulkers ne sont plus une menace !"
+
+  - type: CRAFT
+    actions:
+      - material: SHULKER_BOX
+    name: "rang11_mission9_shulker_box_craft"
+    display-name: "Rang 11 - Mission 9"
+    description: "#edacfcCrafter #ff94d764 #edacfcboîtes de Shulker"
+    placeholder-description: "#edacfcCrafter #ff94d7%quest-remaining% #edacfcboîtes de Shulker"
+    thumbnail: SHULKER_BOX
+    goal: 64
+    auto-accept: true
+    rewards:
+      - type: message
+        messages:
+          - "#edacfcTon inventaire est prêt pour l'expédition dans l'End."
+


### PR DESCRIPTION
## Summary
- add quest definitions for rank 11 mission 9 covering end-themed objectives
- add quest definitions for rank 11 mission 10 focused on deliveries to the intendant
- add a dedicated inventory layout for browsing rank 11 missions

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68f3b4f0bed883219ca874f8096910fc